### PR TITLE
Simple shell script to allow users to hack on stenographer locally.

### DIFF
--- a/change_git_user.sh
+++ b/change_git_user.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <github_username>"
+  exit 1
+fi
+
+set -e
+set -x
+
+cd $(dirname $0)
+
+for file in $(find . -type f -name '*.go'); do
+  echo "Rewriting imports in $file"
+  sed -i "s#github.com/.*/stenographer#github.com/$1/stenographer#" $file
+done


### PR DESCRIPTION
Finds and fixes all github import paths to match the given user.  Of course,
they should all be changed back to 'google' before a pull request is issued.
