### PR TITLE
Plumbing to pass context.Context through a Lookup. 

### DIFF
--- a/blockfile/blockfile.go
+++ b/blockfile/blockfile.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/stenographer/base"
 	"github.com/google/stenographer/indexfile"
 	"github.com/google/stenographer/query"
+	"golang.org/x/net/context"
 )
 
 // #include <linux/if_packet.h>
@@ -187,7 +188,7 @@ func (b *BlockFile) AllPackets() Iter {
 	return &allPacketsIter{BlockFile: b}
 }
 
-func (b *BlockFile) Lookup(q query.Query) *base.PacketChan {
+func (b *BlockFile) Lookup(ctx context.Context, q query.Query) *base.PacketChan {
 	b.mu.RLock()
 	c := base.NewPacketChan(100)
 	go func() {
@@ -195,7 +196,7 @@ func (b *BlockFile) Lookup(q query.Query) *base.PacketChan {
 		var ci gopacket.CaptureInfo
 		v(3, "Blockfile %q looking up query %q", q.String(), b.name)
 		start := time.Now()
-		positions, err := q.LookupIn(b.i)
+		positions, err := q.LookupIn(ctx, b.i)
 		if err != nil {
 			c.Close(fmt.Errorf("index lookup failure: %v", err))
 			return
@@ -204,6 +205,10 @@ func (b *BlockFile) Lookup(q query.Query) *base.PacketChan {
 			v(2, "Blockfile %q reading all packets", b.name)
 			iter := &allPacketsIter{BlockFile: b}
 			for iter.Next() {
+				if err := ctx.Err(); err != nil {
+					c.Close(err)
+					return
+				}
 				c.Send(iter.Packet())
 			}
 			if iter.Err() != nil {
@@ -213,6 +218,10 @@ func (b *BlockFile) Lookup(q query.Query) *base.PacketChan {
 		} else {
 			v(2, "Blockfile %q reading %v packets", b.name, len(positions))
 			for _, pos := range positions {
+				if err := ctx.Err(); err != nil {
+					c.Close(err)
+					return
+				}
 				buffer, err := b.readPacket(pos, &ci)
 				if err != nil {
 					c.Close(fmt.Errorf("error reading packets from %q @ %v: %v", b.name, pos, err))

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,7 @@ import (
 	"github.com/google/stenographer/blockfile"
 	"github.com/google/stenographer/indexfile"
 	"github.com/google/stenographer/query"
+	"golang.org/x/net/context"
 )
 
 var v = base.V // verbose logging
@@ -219,17 +220,17 @@ func (st *stenotypeThread) untrackFile(filename string) error {
 	return nil
 }
 
-func (st *stenotypeThread) lookup(q query.Query) *base.PacketChan {
+func (st *stenotypeThread) lookup(ctx context.Context, q query.Query) *base.PacketChan {
 	st.mu.RLock()
 	defer st.mu.RUnlock()
 	var inputs []*base.PacketChan
 	for _, file := range st.files {
-		inputs = append(inputs, file.Lookup(q))
+		inputs = append(inputs, file.Lookup(ctx, q))
 	}
 	// BUG:  MergePacketChans returns asynchronously, so there's a chance
 	// that we'll lose our st.mu lock while still looking up packets, then
 	// close/delete files.  Figure out how to fix this.
-	return base.MergePacketChans(inputs)
+	return base.MergePacketChans(ctx, inputs)
 }
 
 func (st *stenotypeThread) getBlockFile(name string) *blockfile.BlockFile {
@@ -352,10 +353,10 @@ func (d *Directory) Path() string {
 	return d.name
 }
 
-func (d *Directory) Lookup(q query.Query) *base.PacketChan {
+func (d *Directory) Lookup(ctx context.Context, q query.Query) *base.PacketChan {
 	var inputs []*base.PacketChan
 	for _, thread := range d.threads {
-		inputs = append(inputs, thread.lookup(q))
+		inputs = append(inputs, thread.lookup(ctx, q))
 	}
-	return base.MergePacketChans(inputs)
+	return base.MergePacketChans(ctx, inputs)
 }

--- a/indexfile/indexfile.go
+++ b/indexfile/indexfile.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/google/stenographer/base"
 	"github.com/google/stenographer/sstable"
+	"golang.org/x/net/context"
 )
 
 var v = base.V // verbose logging locally.
@@ -67,7 +68,7 @@ func (i *IndexFile) Name() string {
 // IPPositions returns the positions in the block file of all packets with IPs
 // between the given ranges.  Both IPs must be 4 or 16 bytes long, both must be
 // the same length, and from must be <= to.
-func (i *IndexFile) IPPositions(from, to net.IP) (base.Positions, error) {
+func (i *IndexFile) IPPositions(ctx context.Context, from, to net.IP) (base.Positions, error) {
 	var version byte
 	switch {
 	case len(from) != len(to):
@@ -82,23 +83,24 @@ func (i *IndexFile) IPPositions(from, to net.IP) (base.Positions, error) {
 		return nil, fmt.Errorf("Invalid IP length")
 	}
 	return i.positions(
+		ctx,
 		append([]byte{version}, []byte(from)...),
 		append([]byte{version}, []byte(to)...))
 }
 
 // ProtoPositions returns the positions in the block file of all packets with
 // the give IP protocol number.
-func (i *IndexFile) ProtoPositions(proto byte) (base.Positions, error) {
-	return i.positionsSingleKey([]byte{1, proto})
+func (i *IndexFile) ProtoPositions(ctx context.Context, proto byte) (base.Positions, error) {
+	return i.positionsSingleKey(ctx, []byte{1, proto})
 }
 
 // ProtoPositions returns the positions in the block file of all packets with
 // the give port number (TCP or UDP).
-func (i *IndexFile) PortPositions(port uint16) (base.Positions, error) {
+func (i *IndexFile) PortPositions(ctx context.Context, port uint16) (base.Positions, error) {
 	var buf [3]byte
 	binary.BigEndian.PutUint16(buf[1:], port)
 	buf[0] = 2
-	return i.positionsSingleKey(buf[:])
+	return i.positionsSingleKey(ctx, buf[:])
 }
 
 // Dump writes out a debug version of the entire index to the given writer.
@@ -112,12 +114,12 @@ func (i *IndexFile) Dump(out io.Writer) {
 	}
 }
 
-func (i *IndexFile) positionsSingleKey(key []byte) (base.Positions, error) {
+func (i *IndexFile) positionsSingleKey(ctx context.Context, key []byte) (base.Positions, error) {
 	var sortedPos base.Positions
 	v(4, "%q single key iterator %+v start", i.name, key)
 	iter := i.ss.Iter(key)
 	count := int64(0)
-	for iter.Next() {
+	for ctx.Err() == nil && iter.Next() {
 		if !bytes.Equal(key, iter.Key()) {
 			v(4, "%q single key iterator high key %v", i.name, iter.Key())
 			break
@@ -132,18 +134,22 @@ func (i *IndexFile) positionsSingleKey(key []byte) (base.Positions, error) {
 		v(4, "%q single key iterator err=%v", i.name, err)
 		return nil, err
 	}
+	if err := ctx.Err(); err != nil {
+		v(4, "%q single key iterator ctx err=%v", i.name, err)
+		return nil, err
+	}
 	return sortedPos, nil
 }
 
-func (i *IndexFile) positions(from, to []byte) (base.Positions, error) {
+func (i *IndexFile) positions(ctx context.Context, from, to []byte) (base.Positions, error) {
 	if bytes.Equal(from, to) {
-		return i.positionsSingleKey(from)
+		return i.positionsSingleKey(ctx, from)
 	}
 	v(4, "%q multi key iterator %v:%v start", i.name, from, to)
 	iter := i.ss.Iter(from)
 	positions := map[uint32]bool{}
 	count := int64(0)
-	for iter.Next() {
+	for ctx.Err() == nil && iter.Next() {
 		if bytes.Compare(iter.Key(), from) > 0 {
 			v(4, "%q multi key iterator high key %v", i.name, iter.Key())
 			break
@@ -156,6 +162,10 @@ func (i *IndexFile) positions(from, to []byte) (base.Positions, error) {
 	v(4, "%q multi key iterator done", i.name)
 	if err := iter.Err(); err != nil {
 		v(4, "%q multi key iterator err=%v", i.name, err)
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		v(4, "%q single key iterator ctx err=%v", i.name, err)
 		return nil, err
 	}
 	sortedPos := make(base.Positions, 0, len(positions))


### PR DESCRIPTION
Plumb a context.Context through a lookup, so that when a user cancels the HTTP request or loses a connection, we don't continue to process their request.  This is especially important for huge queries like 'port=80' or 'protocol=6', which take very large amounts of time to look up indexes, let alone pulling the actual packets out of the blockfiles.
