### PR TITLE
Call periodic callbacks immediately on startup.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -351,6 +351,7 @@ func (d *Directory) Close() error {
 func (d *Directory) callEvery(cb func(), freq time.Duration) {
 	ticker := time.NewTicker(freq)
 	defer ticker.Stop()
+	cb() // Call function immediately the first time around.
 	for {
 		select {
 		case <-d.done:


### PR DESCRIPTION
Call periodic callbacks immediately when callback calling goroutine is started up.  In particular, this means that the first steno scan of disk doesn't take 15 seconds to run.
