### PR TITLE
Only log when there are errors or requests.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -141,7 +141,7 @@ func (st *stenotypeThread) syncFilesWithDisk() {
 		newFilesCnt++
 	}
 	if newFilesCnt > 0 {
-		log.Printf("Thread %v found %d new blockfiles", st.id, newFilesCnt)
+		v(1, "Thread %v found %d new blockfiles", st.id, newFilesCnt)
 	}
 }
 
@@ -186,7 +186,7 @@ func (st *stenotypeThread) cleanUpOnLowDiskSpace() {
 			v(1, "Thread %v disk space is sufficient: %v > %v", st.id, df, st.minDiskFree)
 			return
 		}
-		log.Printf("Thread %v disk usage is high (packet path=%q): %d%% free\n", st.id, st.packetPath, df)
+		v(1, "Thread %v disk usage is high (packet path=%q): %d%% free\n", st.id, st.packetPath, df)
 		if err := st.deleteOlderThreadFiles(); err != nil {
 			log.Printf("Thread %v could not free up space by deleting old files: %v", st.id, err)
 			return
@@ -270,7 +270,7 @@ func (st *stenotypeThread) getBlockFile(name string) *blockfile.BlockFile {
 // ReadConfigFile reads in the given JSON encoded configuration file and returns
 // the Config object associated with the decoded configuration data.
 func ReadConfigFile(filename string) (*Config, error) {
-	log.Printf("Reading config %q", filename)
+	v(1, "Reading config %q", filename)
 	data, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("could not read config file %q: %v", filename, err)
@@ -362,9 +362,8 @@ func (c Config) Directory() (_ *Directory, returnedErr error) {
 // Stenotype returns a exec.Cmd which runs the stenotype binary with all of
 // the appropriate flags.
 func (c Config) Stenotype(d *Directory) *exec.Cmd {
-	log.Printf("Starting stenotype")
 	args := append(c.args(), fmt.Sprintf("--dir=%s", d.Path()))
-	v(1, "Starting as %q with args %q", c.StenotypePath, args)
+	v(1, "Starting stenotype as %q with args %q", c.StenotypePath, args)
 	return exec.Command(c.StenotypePath, args...)
 }
 

--- a/stenographer.go
+++ b/stenographer.go
@@ -104,7 +104,7 @@ func runStenotype(conf *config.Config, dir *config.Directory) {
 		start := time.Now()
 		err := runStenotypeOnce(conf, dir)
 		duration := time.Since(start)
-		log.Printf("Stenotype ran for %v: %v", duration, err)
+		log.Printf("Stenotype stopped after %v: %v", duration, err)
 		if duration < minStenotypeRuntimeForRestart {
 			log.Fatalf("Stenotype ran for too little time, crashing to avoid stenotype crash loop")
 		}

--- a/stenotype/aio.cc
+++ b/stenotype/aio.cc
@@ -32,14 +32,12 @@ class SingleFile;
 class PWrite {
  public:
   PWrite(Block* b, SingleFile* f) {
-    LOG(V3) << "PWriteBlockConstructor b" << int64_t(b)
-            << " INTO b" << int64_t(&block);
+    LOG(V3) << "PWriteBlockConstructor b" << int64_t(b) << " INTO b"
+            << int64_t(&block);
     block.Swap(b);
     file = f;
   }
-  ~PWrite() {
-    LOG(V3) << "PWriteBLockDestructor b" << int64_t(&block);
-  }
+  ~PWrite() { LOG(V3) << "PWriteBLockDestructor b" << int64_t(&block); }
 
   Error Done(io_event* evt);
 

--- a/stenotype/index.cc
+++ b/stenotype/index.cc
@@ -170,7 +170,8 @@ string Hex(const char* start, int size) {
 
 void WriteToIndex(char first, const char* start, int size, int64_t pos,
                   leveldb::TableBuilder* ss) {
-  LOG(V4) << "Writing index " << int(first) << ":*" << size << ")" << Hex(start, size) << "=" << pos;
+  LOG(V4) << "Writing index " << int(first) << ":*" << size << ")"
+          << Hex(start, size) << "=" << pos;
   char buf[17];
   CHECK(size <= 16);
   CHECK(pos < int64_t(1) << 32);

--- a/stenotype/packets.cc
+++ b/stenotype/packets.cc
@@ -374,8 +374,8 @@ Error PacketsV3::NextBlock(Block* b, bool poll_once) {
   }
   if (pos_.ReadyForUser()) {
     pos_.UpdateStats(&stats_);
-    LOG(V3) << "PacketsV3NextBlock b"
-            << int64_t(&pos_) << " INTO b" << int64_t(b);
+    LOG(V3) << "PacketsV3NextBlock b" << int64_t(&pos_) << " INTO b"
+            << int64_t(b);
     pos_.Swap(b);
   }
   return SUCCESS;

--- a/stenotype/stenotype.cc
+++ b/stenotype/stenotype.cc
@@ -111,9 +111,6 @@ int ParseOptions(int key, char* arg, struct argp_state* state) {
     case 'v':
       st::logging_verbose_level++;
       break;
-    case 'q':
-      st::logging_verbose_level--;
-      break;
     case 300:
       flag_iface = arg;
       break;
@@ -171,7 +168,6 @@ void ParseOptions(int argc, char** argv) {
   const char* n = "NUM";
   struct argp_option options[] = {
       {0, 'v', 0, 0, "Verbose logging, may be given multiple times"},
-      {0, 'q', 0, 0, "Quiet logging.  Each -q counteracts one -v"},
       {"iface", 300, s, 0, "Interface to read packets from"},
       {"dir", 301, s, 0, "Directory to store packet files in"},
       {"count", 302, n, 0,
@@ -215,8 +211,8 @@ void DropPrivileges() {
     if (flag_gid == "") {
       flag_gid = "nobody";
     }
-    LOG(INFO) << "Dropping priviledges from " << getgid()
-              << " to GID " << flag_gid;
+    LOG(INFO) << "Dropping priviledges from " << getgid() << " to GID "
+              << flag_gid;
     auto group = getgrnam(flag_gid.c_str());
     CHECK(group != NULL) << "Unable to get info for user " << flag_gid;
     CHECK_SUCCESS(Errno(setgid(group->gr_gid)));
@@ -227,8 +223,8 @@ void DropPrivileges() {
     if (flag_uid == "") {
       flag_uid = "nobody";
     }
-    LOG(INFO) << "Dropping priviledges from " << getuid()
-              << " to UID " << flag_uid;
+    LOG(INFO) << "Dropping priviledges from " << getuid() << " to UID "
+              << flag_uid;
     auto passwd = getpwnam(flag_uid.c_str());
     CHECK(passwd != NULL) << "Unable to get info for user 'nobody'";
     flag_uid = passwd->pw_uid;

--- a/stenotype/util.cc
+++ b/stenotype/util.cc
@@ -19,7 +19,7 @@
 
 namespace st {
 
-int logging_verbose_level = 0;
+int logging_verbose_level = -1;  // by default, log ERROR only
 
 // When implementing basename and dirname, we copy everything to a buffer, then
 // call libgen's basename()/dirname() functions on that buffer.  We do this

--- a/stenotype/util.h
+++ b/stenotype/util.h
@@ -116,8 +116,8 @@ class LogLine {
     FillTimeBuffer();
     uint32_t tid = uint32_t(pthread_self()) >> 8;  // first bits always 0.
     ss_ << setfill('0') << time_buffer_ << "." << setw(6) << tv_.tv_usec
-        << "Z T:" << std::hex << setw(6) << tid
-        << setw(0) << std::dec << " [" << file << ":" << line << "] ";
+        << "Z T:" << std::hex << setw(6) << tid << setw(0) << std::dec << " ["
+        << file << ":" << line << "] ";
   }
   ~LogLine() {
     ss_ << "\n";


### PR DESCRIPTION
This change means that by default, we won't log much at all unless there are
errors (directory/file issues, etc) or user requests (someone requests
information via HTTP).  This gets us more in line with the unix-y method of only
logging when something goes wrong.
