### PR TITLE
Break up stenoread into stenocurl, so we can access /debug.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -132,10 +132,13 @@ sudo chown stenographer:root "$BINDIR/stenotype"
 sudo chmod 0700 "$BINDIR/stenotype"
 sudo setcap 'CAP_NET_RAW+ep CAP_NET_ADMIN+ep CAP_IPC_LOCK+ep' "$BINDIR/stenotype"
 
-Info "Copying stenoread"
+Info "Copying stenoread/stenocurl"
 sudo cp -vf stenoread "$BINDIR/stenoread"
 sudo chown stenographer:stenographer "$BINDIR/stenoread"
 sudo chmod 0750 "$BINDIR/stenoread"
+sudo cp -vf stenocurl "$BINDIR/stenocurl"
+sudo chown stenographer:stenographer "$BINDIR/stenocurl"
+sudo chmod 0750 "$BINDIR/stenocurl"
 
 Info "Starting stenographer"
 sudo -u stenographer -b "$BINDIR/stenographer" &

--- a/stenocurl
+++ b/stenocurl
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# stenocurl is a simple wrapper around curl which:
+#   * finds where the server is based on the config
+#   * sets the correct flags to do client and server verification via SSL
+# To run stenocurl, one must have read access to the stenographer client
+# key, which generally means one must be in the 'stenographer' group.
+
+JQ="$(which jq)"
+if [ -z "$JQ" ]; then
+  echo "Must install 'jq' for JSON parsing (apt-get install jq)" >&2
+  exit 1
+fi
+
+if [ "$#" -lt 1 -o ${1:0:1} != "/" ]; then
+  /bin/cat >&2 <<EOF
+USAGE: $0 /<path> [curl args...]
+
+Runs 'curl' against https://stenographerserver/path, returning data on STDOUT.
+Any arguments after the first are passed directly to 'curl'.
+
+This script is mostly used to access /debug/XXX URLs for Stenographer... for
+accessing packets, it's probably better to use the 'stenoread' wrapper around
+this script, which correctly passes packet requests into steno, then passes
+the results through tcpdump for easier handling.
+EOF
+  exit 1
+fi
+PATH="$1"  # starts with '/'
+shift
+
+STENOGRAPHER_CONFIG="${STENOGRAPHER_CONFIG-/etc/stenographer/config}"
+
+if [ ! -r "$STENOGRAPHER_CONFIG" ]; then
+  /bin/cat >&2 <<EOF
+Unable to access stenographer config at '$STENOGRAPHER_CONFIG'.  You may need
+to set the STENOGRAPHER_CONFIG environmental variable to point to the correct
+location of your config, or you may need to request read access to that file.
+EOF
+  exit 1
+fi
+
+PORT="$(/bin/cat "$STENOGRAPHER_CONFIG" | $JQ -r '.Port')"
+CERTPATH="$(/bin/cat "$STENOGRAPHER_CONFIG" | $JQ -r '.CertPath')"
+if [ -z "$PORT" -o -z "$CERTPATH" ]; then
+  echo "Unable to get port ($PORT) or certpath ($CERTPATH) from config ($STENOGRAPHER_CONFIG)" >&2
+  exit 1
+fi
+URL="https://localhost:$PORT$PATH"  # PATH already starts with /
+
+if [ ! -r "$CERTPATH/client_key.pem" ]; then
+  echo "You do not have permission to access Stenographer data" >&2
+  exit 1
+fi
+
+/usr/bin/curl \
+    --cert "$CERTPATH/client_cert.pem" \
+    --key "$CERTPATH/client_key.pem" \
+    --cacert "$CERTPATH/server_cert.pem" \
+    "$@" \
+    "$URL"

--- a/stenoread
+++ b/stenoread
@@ -13,13 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if ! which jq >/dev/null; then
-  echo "Must install 'jq' for JSON parsing (apt-get install jq)"
-  exit 1
-fi
-
 if [ "$#" -lt 1 ]; then
-  cat 1>&2 <<EOF
+  cat >&2 <<EOF
 $0 provides a simple method for reading logs out of stenographer.
 Its first argument is the query to send to stenographer, all other arguments
 are passed to TCPDump.
@@ -40,35 +35,12 @@ EOF
   exit 1
 fi
 
-STENOGRAPHER_CONFIG="${STENOGRAPHER_CONFIG-/etc/stenographer/config}"
-
-if [ ! -r "$STENOGRAPHER_CONFIG" ]; then
-  echo "You do not have permission to access Stenographer packets"
-  exit 1
-fi
-
-PORT="$(cat "$STENOGRAPHER_CONFIG" | jq -r '.Port')"
-CERTPATH="$(cat "$STENOGRAPHER_CONFIG" | jq -r '.CertPath')"
-if [ -z "$PORT" -o -z "$CERTPATH" ]; then
-  echo "Unable to get port ($PORT) or certpath ($CERTPATH) from config ($STENOGRAPHER_CONFIG)" 1>&2
-  exit 1
-fi
-SERVER="localhost:$PORT"
 STENOQUERY="$1"
 shift
 
-if [ ! -r "$CERTPATH/client_key.pem" ]; then
-  echo "You do not have permission to access Stenographer packets"
-  exit 1
-fi
-
-echo "Running stenotype query '$STENOQUERY' against '$SERVER'" 1>&2
-curl \
+echo "Running stenographer query '$STENOQUERY', piping to 'tcpdump $@'" >&2
+$(dirname $0)/stenocurl /query \
     -d "$STENOQUERY" \
-    --cert "$CERTPATH/client_cert.pem" \
-    --key "$CERTPATH/client_key.pem" \
-    --cacert "$CERTPATH/server_cert.pem" \
     --silent \
-    --show-error \
-    "https://$SERVER/query" |
+    --show-error |
     tcpdump -r /dev/stdin -s 0 "$@"


### PR DESCRIPTION
We now have some very useful HTTP handlers in /debug/*, but they're protected by certs just like /query, so they require a lot of command line flags to get access to.  We already have scripted how to get those flags in stenoread, so just refactor that out into its own script (stenocurl), then have stenoread call it.
