### PR TITLE
Use one index queue per thread.

### DIFF
--- a/stenotype/util.h
+++ b/stenotype/util.h
@@ -395,6 +395,7 @@ class Watchdog {
       LOG(FATAL) << "WATCHDOG FAILURE: " << description_;
     }
   }
+
  public:
   Watchdog(std::string description, int seconds)
       : description_(description), seconds_(seconds), ctr_(0), done_(false) {


### PR DESCRIPTION
Before this, we would crash occasionally when one thread would take an index,
write it, and take another, starving another index thread from getting an index
to write.  That meant that the starved thread wouldn't feed its watchdog in
time, crashing the system.

Now, we have a very nice architecture of:
  thread_1 -> write_index_queue_1 -> write_thread_1
  thread_2 -> write_index_queue_2 -> write_thread_2
  ...
  thread_N -> write_index_queue_N -> write_thread_N

Thus, write_index thread N can act as a check on thread N by making sure it gets
an index regularly, which is what we've set up the watchdogs to do.
