### PR TITLE
Fix crashing bugs.

### DIFF
--- a/stenotype/index.cc
+++ b/stenotype/index.cc
@@ -217,26 +217,42 @@ Error Index::Flush() {
   WriteToIndex(kIndexVersion, NULL, 0, kIndexVersionNumber, &index_ss);
 
   for (auto iter : proto_) {
-    for (auto pos : iter.second) {
-      WriteToIndex(kIndexProtocol, reinterpret_cast<const char*>(&iter.first),
-                   1, pos, &index_ss);
+    int64_t last_pos = 0;
+    for (int64_t pos : iter.second) {
+      if (pos > last_pos) {
+        WriteToIndex(kIndexProtocol, reinterpret_cast<const char*>(&iter.first),
+                     1, pos, &index_ss);
+      }
+      last_pos = pos;
     }
   }
   for (auto iter : port_) {
     uint16_t port = htons(iter.first);
-    for (auto pos : iter.second) {
-      WriteToIndex(kIndexPort, reinterpret_cast<const char*>(&port), 2, pos,
-                   &index_ss);
+    int64_t last_pos = 0;
+    for (int64_t pos : iter.second) {
+      if (pos > last_pos) {
+        WriteToIndex(kIndexPort, reinterpret_cast<const char*>(&port), 2, pos,
+                     &index_ss);
+      }
+      last_pos = pos;
     }
   }
   for (auto iter : ip4_) {
-    for (auto pos : iter.second) {
-      WriteToIndex(kIndexIPv4, iter.first.data(), 4, pos, &index_ss);
+    int64_t last_pos = 0;
+    for (int64_t pos : iter.second) {
+      if (pos > last_pos) {
+        WriteToIndex(kIndexIPv4, iter.first.data(), 4, pos, &index_ss);
+      }
+      last_pos = pos;
     }
   }
   for (auto iter : ip6_) {
-    for (auto pos : iter.second) {
-      WriteToIndex(kIndexIPv6, iter.first.data(), 16, pos, &index_ss);
+    int64_t last_pos = 0;
+    for (int64_t pos : iter.second) {
+      if (pos > last_pos) {
+        WriteToIndex(kIndexIPv6, iter.first.data(), 16, pos, &index_ss);
+      }
+      last_pos = pos;
     }
   }
   auto finished = index_ss.Finish();

--- a/stenotype/stenotype.cc
+++ b/stenotype/stenotype.cc
@@ -338,6 +338,7 @@ Error SetAffinity(int cpu) {
 }
 
 void WriteIndexes(int thread, st::ProducerConsumerQueue* write_index) {
+  LOG(V1) << "Starting WriteIndexes thread " << thread;
   Watchdog dog("WriteIndexes thread " + std::to_string(thread),
                flag_fileage_sec * 3);
   pid_t tid = syscall(SYS_gettid);
@@ -348,11 +349,12 @@ void WriteIndexes(int thread, st::ProducerConsumerQueue* write_index) {
   while (true) {
     LOG(V1) << "Waiting for index";
     Index* i = reinterpret_cast<Index*>(write_index->Get());
-    LOG(INFO) << "Got index " << int64_t(i);
+    LOG(V1) << "Got index " << int64_t(i);
     if (i == NULL) {
       break;
     }
     LOG_IF_ERROR(i->Flush(), "index flush");
+    LOG(V1) << "Wrote index " << int64_t(i);
     delete i;
     dog.Feed();
   }
@@ -438,45 +440,17 @@ void RunThread(int thread, st::ProducerConsumerQueue* write_index) {
   int64_t lastlog = 0;
   int64_t blocks = 0;
   int64_t block_offset = 0;
-  int64_t errors = 0;  // allows us to ignore spurious errors.
   for (int64_t remaining = flag_count; remaining != 0 && run_threads;) {
     LOG_IF_ERROR(output.CheckForCompletedOps(false), "check for completed");
-    // Read in a new block from AF_PACKET.
-    Block b;
-    CHECK_SUCCESS(v3->NextBlock(&b, kNumMillisPerSecond));
-    if (b.Empty()) {
-      continue;
-    }
-
-    // Index all packets if necessary.
-    if (flag_index) {
-      for (; remaining != 0 && b.Next(&p); remaining--) {
-        index->Process(p, block_offset << 20);
-      }
-    }
-
-    // Iterate over all packets in the block.  Currently unused, but
-    // eventually packet indexing will go here.
-    blocks++;
-    block_offset++;
-
-    // Start an async write of the current block.  Could block
-    // waiting for the write 'aiops' writes ago.
-    Error write_err = output.Write(&b);
-    if (!SUCCEEDED(write_err)) {
-      LOG(ERROR) << "output write error: " << *write_err;
-      errors++;
-      CHECK(errors < 5) << "Too many errors in close proximity";
-    } else if (errors > 0) {
-      errors--;
-    }
-
     int64_t current_micros = GetCurrentTimeMicros();
+
     // Rotate file if necessary.
     int64_t current_file_age_secs =
         (current_micros - micros) / kNumMicrosPerSecond;
     if (block_offset == flag_filesize_mb ||
         current_file_age_secs > flag_fileage_sec) {
+      LOG(V1) << "Rotating file " << micros << " with " << block_offset
+              << " blocks";
       // File size got too big, rotate file.
       micros = current_micros;
       block_offset = 0;
@@ -486,7 +460,6 @@ void RunThread(int thread, st::ProducerConsumerQueue* write_index) {
         index = new Index(index_dirname, micros);
       }
     }
-
     // Log stats every 100MB or at least 1/minute.
     if (blocks % 100 == 0 ||
         lastlog < current_micros - 60 * kNumMicrosPerSecond) {
@@ -502,6 +475,26 @@ void RunThread(int thread, st::ProducerConsumerQueue* write_index) {
         LOG(ERROR) << "Unable to get stats: " << *stats_err;
       }
     }
+
+    // Read in a new block from AF_PACKET.
+    Block b;
+    CHECK_SUCCESS(v3->NextBlock(&b, kNumMillisPerSecond));
+    if (b.Empty()) {
+      continue;
+    }
+
+    // Index all packets if necessary.
+    if (flag_index) {
+      for (; remaining != 0 && b.Next(&p); remaining--) {
+        index->Process(p, block_offset << 20);
+      }
+    }
+    blocks++;
+    block_offset++;
+
+    // Start an async write of the current block.  Could block
+    // waiting for the write 'aiops' writes ago.
+    CHECK_SUCCESS(output.Write(&b));
     dog.Feed();
   }
   LOG(V1) << "Finishing thread " << thread;


### PR DESCRIPTION
Fix two crashing bugs.  The first, most serious one is that certain leveldb
versions will crash if they get the same key.  We mostly handled this before
(commit 7409668cf50f43c0b9475e5654fed6cca906ef7c), but we didn't handle the case
where one packet has the same src/dst IP or (more likely) port.  In that case,
we still used to write <port><position> <port><same position>, which violated
the same-key invariant.  We now watch for the same position coming up multiple
times for the same key when doing index writes (changes in index.cc).

The less critical but still important issue is that WriteIndexes has a watchdog
and requires that it gets a new index every X seconds.  However, our main loop
in RunThread used to loop forever if it got no packets, without doing that.  We
now change that, so it checks for file rotation before checking for a new block.
This also fixes possibly strange behavior of opening a file at timestamp X,
getting zero packets for an hour, then writing packets into the X timestamp file
(because we didn't check for rotation utnil after we got the block).  This also
violated a stenographer invariant that file name order denoted packet order.
