### PR TITLE
Fix setuid/setgid.

### DIFF
--- a/stenotype/aio.cc
+++ b/stenotype/aio.cc
@@ -131,10 +131,7 @@ Error SingleFile::Close() {
 
 }  // namespace io
 
-Output::Output(int aiops)
-    : ctx_(NULL),
-      max_ops_(aiops),
-      current_(NULL) {
+Output::Output(int aiops) : ctx_(NULL), max_ops_(aiops), current_(NULL) {
   CHECK_SUCCESS(SetUp());
 }
 
@@ -181,8 +178,8 @@ Error Output::MaybeCloseFile(io::SingleFile* file) {
   return SUCCESS;
 }
 
-Error Output::Rotate(
-    const std::string& dirname, int64_t micros, int64_t initial_size) {
+Error Output::Rotate(const std::string& dirname, int64_t micros,
+                     int64_t initial_size) {
   if (current_) {
     current_->RequestClose();
     RETURN_IF_ERROR(MaybeCloseFile(current_), "maybe close");
@@ -193,8 +190,7 @@ Error Output::Rotate(
   LOG(INFO) << "Opening packet file " << name << ": " << fd;
   RETURN_IF_ERROR(Errno(fd > 0), "open");
   if (initial_size > 0) {
-    LOG_IF_ERROR(Errno(0 <= fallocate(fd, 0, 0, initial_size)),
-                 "fallocate");
+    LOG_IF_ERROR(Errno(0 <= fallocate(fd, 0, 0, initial_size)), "fallocate");
   }
   current_ = new io::SingleFile(this, dirname, micros, fd);
   files_.insert(current_);

--- a/stenotype/aio.h
+++ b/stenotype/aio.h
@@ -49,8 +49,8 @@ class Output {
   // Open a new file.  Will fail if a file is already open.
   // If initial_size > 0, will attempt to preallocate the file to be
   // that many bytes.
-  Error Rotate(
-      const std::string& dirname, int64_t micros, int64_t initial_size);
+  Error Rotate(const std::string& dirname, int64_t micros,
+               int64_t initial_size);
   // Close and flush all files.
   Error Flush();
   // Write the given Block out to the given offset in the current file,

--- a/stenotype/index.cc
+++ b/stenotype/index.cc
@@ -255,7 +255,7 @@ const char kIndexIPv6 = 6;
 }  // namespace
 
 Error Index::Flush() {
-  leveldb::WritableFile* file;
+  leveldb::WritableFile* file = NULL;
   std::string filename = HiddenFile(dirname_, micros_);
   auto status = leveldb::Env::Default()->NewWritableFile(filename, &file);
   if (!status.ok()) {

--- a/stenotype/util.cc
+++ b/stenotype/util.cc
@@ -119,14 +119,22 @@ void Watchdog::Watch() {
 }
 
 Watchdog::Watchdog(std::string description, int seconds)
-    : description_(description), seconds_(seconds), ctr_(0), done_(false) {
-  t_ = new std::thread(&Watchdog::Watch, this);
+    : t_(NULL),
+      description_(description),
+      seconds_(seconds),
+      ctr_(0),
+      done_(false) {
+  if (seconds > 0) {
+    t_ = new std::thread(&Watchdog::Watch, this);
+  }
 }
 
 Watchdog::~Watchdog() {
   done_ = true;
-  t_->join();
-  delete t_;
+  if (t_ != NULL) {
+    t_->join();
+    delete t_;
+  }
 }
 
 void Watchdog::Feed() { ctr_++; }

--- a/stenotype/util.h
+++ b/stenotype/util.h
@@ -347,6 +347,7 @@ inline std::string UnhiddenFile(const std::string& dirname, int64_t micros) {
 class Watchdog {
  public:
   // Create a watchdog that crashes if it hasn't been fed after X seconds.
+  // If 'seconds' is <= zero, does nothing.
   Watchdog(std::string description, int seconds);
 
   // Constructor stops the watchdog.


### PR DESCRIPTION
Actually, this CL does a couple of things:

-- Fix setuid/setgid:

We were calling setuid/setgid AFTER creating some threads and doing some signal
handling stuff... first off, this didn't guarantee that all threads were in fact
set up with the correct uid/gid.  Secondly, it appeared to cause hanging in
certain cases, I believe because of failed delivery of a SIGSETXID.  This meant
that running as root with '--uid=foo --gid=bar' hung forever on a setgid call.

-- Formatting

Ran clang C++ formatter, which moved some arguments around.

-- Watchdog disabling

Added a flag to disable watchdogs for debugging purposes.  This makes using GDB
and the like easier, because your process won't crash during a debugging session
due to a hungry puppy.
