### PR TITLE
Don't run stenographer/stenotype as group stenographer.

### DIFF
--- a/configs/upstart.conf
+++ b/configs/upstart.conf
@@ -26,7 +26,7 @@ respawn
 respawn limit 1 300  # At most once per 5 minutes
 
 setuid stenographer
-setgid stenographer
+setgid nogroup
 limit nofile 1000000 1000000
 limit fsize 4294967296 4294967296
 exec /usr/bin/stenographer

--- a/install.sh
+++ b/install.sh
@@ -61,10 +61,11 @@ fi
 if [ ! -d /etc/stenographer/certs ]; then
   Info "Setting up stenographer /etc directory"
   sudo mkdir -p /etc/stenographer/certs
+  sudo chown -R stenographer:stenographer /etc/stenographer/certs
   if [ ! -f /etc/stenographer/config ]; then
     sudo cp -vf configs/steno.conf /etc/stenographer/config
   fi
-  sudo chown -R stenographer:stenographer /etc/stenographer
+  sudo chown root:root /etc/stenographer /etc/stenographer/config
 fi
 
 if [ ! -d "$OUTDIR" ]; then
@@ -86,16 +87,16 @@ make
 popd
 sudo cp -vf stenotype/stenotype "$BINDIR/stenotype"
 sudo chown stenographer:root "$BINDIR/stenotype"
-sudo chmod 0700 "$BINDIR/stenotype"
+sudo chmod 0500 "$BINDIR/stenotype"
 SetCapabilities "$BINDIR/stenotype"
 
 Info "Copying stenoread/stenocurl"
 sudo cp -vf stenoread "$BINDIR/stenoread"
-sudo chown stenographer:stenographer "$BINDIR/stenoread"
-sudo chmod 0750 "$BINDIR/stenoread"
+sudo chown root:root "$BINDIR/stenoread"
+sudo chmod 0755 "$BINDIR/stenoread"
 sudo cp -vf stenocurl "$BINDIR/stenocurl"
-sudo chown stenographer:stenographer "$BINDIR/stenocurl"
-sudo chmod 0750 "$BINDIR/stenocurl"
+sudo chown root:root "$BINDIR/stenocurl"
+sudo chmod 0755 "$BINDIR/stenocurl"
 
 Info "Starting stenographer"
 sudo -u stenographer -b "$BINDIR/stenographer" &

--- a/stenographer.go
+++ b/stenographer.go
@@ -75,10 +75,10 @@ func main() {
 
 	v(1, "Using config:\n%v", conf)
 	env, err := env.New(*conf)
-	env.StenotypeOutput = stenotypeOutput
 	if err != nil {
 		log.Fatalf("unable to set up stenographer environment: %v", err)
 	}
+	env.StenotypeOutput = stenotypeOutput
 	defer env.Close()
 
 	go env.RunStenotype()

--- a/stenotype/stenotype.cc
+++ b/stenotype/stenotype.cc
@@ -65,6 +65,7 @@
 #include <sys/prctl.h>        // prctl(), PR_SET_*
 #include <sys/resource.h>     // setpriority(), PRIO_PROCESS
 #include <sys/socket.h>       // socket()
+#include <sys/stat.h>         // umask()
 #include <sys/syscall.h>      // syscall(), SYS_gettid
 #include <unistd.h>           // setuid(), setgid()
 
@@ -546,6 +547,9 @@ int Main(int argc, char** argv) {
     CHECK_SUCCESS(builder.Bind(flag_iface, &v3));
     sockets.push_back(v3);
   }
+
+  // To be safe, also set umask before any threads are created.
+  umask(0077);
 
   // Now that we have sockets, drop privileges.
   // We HAVE to do this before we start any threads, since it's unclear whether


### PR DESCRIPTION
Instead, run it as nogroup.  Also, we don't need to make the binaries (with the exception of stenotype) owned by stenographer.  And, make sure we set umask, since leveldb writes based on the process umask and we can't pass it a mode.
