### PR TITLE
Add upper limit to #files/directory.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -122,6 +122,12 @@ to use), you must specify:
      index files take so little space, we haven't ever needed to clean them up
      directly.  Note that `DiskFreePercentage` is optional... it defaults to
      10%.
+   * `MaxDirectoryFiles`:  The maximum number of packet/index files to create
+     before cleaning old ones up.  Defaults to 30K files, to avoid issues with
+     ext3's 32K file-per-directory maximums.  For ext4 you should be able to go
+     higher without issue.  Note that since we create at least one file every
+     minute, this defaults to a maximum limit of 8 1/3 days before we drop old
+     packets.
 
 ### Flags ###
 

--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,13 @@ import (
 )
 
 var v = base.V // verbose logging
-const defaultDiskSpacePercentage = 10
+const (
+	defaultDiskSpacePercentage = 10
+
+	// By default, ext3 has issues with >32k files, so we go for something less
+	// than that.
+	defaultMaxDirectoryFiles = 30000
+)
 
 // ThreadConfig is a json-decoded configuration for each stenotype thread,
 // detailing where it should store data and how much disk space it should keep
@@ -36,6 +42,7 @@ type ThreadConfig struct {
 	PacketsDirectory   string
 	IndexDirectory     string
 	DiskFreePercentage int `json:",omitempty"`
+	MaxDirectoryFiles  int `json:",omitempty"`
 }
 
 // Config is a json-decoded configuration for running stenographer.
@@ -64,6 +71,9 @@ func ReadConfigFile(filename string) (*Config, error) {
 	for i, thread := range out.Threads {
 		if thread.DiskFreePercentage <= 0 {
 			out.Threads[i].DiskFreePercentage = defaultDiskSpacePercentage
+		}
+		if thread.MaxDirectoryFiles <= 0 {
+			thread.MaxDirectoryFiles = defaultMaxDirectoryFiles
 		}
 	}
 	return &out, nil

--- a/thread/thread.go
+++ b/thread/thread.go
@@ -180,11 +180,11 @@ func (t *Thread) cleanUpOnLowDiskSpace() {
 			log.Printf("Thread %v could not get the free disk percentage for %q: %v", t.id, t.packetPath, err)
 			return
 		}
-		if df > t.conf.DiskFreePercentage {
+		if df > t.conf.DiskFreePercentage && len(t.files) < t.conf.MaxDirectoryFiles {
 			v(1, "Thread %v disk space is sufficient: %v > %v", t.id, df, t.conf.DiskFreePercentage)
 			return
 		}
-		v(0, "Thread %v disk usage is high (packet path=%q): %d%% free\n", t.id, t.packetPath, df)
+		v(0, "Thread %v disk usage is high (packet path=%q): %d%% free, %d files\n", t.id, t.packetPath, df, len(t.files))
 		if len(t.files) == 0 {
 			log.Printf("Thread %v could not free up space:  no files available", t.id)
 		} else if err := t.deleteOldestThreadFile(); err != nil {


### PR DESCRIPTION
Some file systems have trouble with large numbers of files (ext3 can't handle
>32K files/directory).  Add a config option to limit the number of files created
before we start to delete them, and default it to 30K.