### PR TITLE
Switch default stenotype gid to 'nogroup'.

### DIFF
--- a/base/base.go
+++ b/base/base.go
@@ -235,6 +235,7 @@ func (a Positions) Sort() {
 
 // Union returns the union of a and b.  a and b must be sorted in advance.
 // Returned slice will be sorted.
+// a or b may be returned by Union, but neither a nor b will be modified.
 func (a Positions) Union(b Positions) (out Positions) {
 	switch {
 	case a.IsAllPositions():
@@ -264,6 +265,7 @@ func (a Positions) Union(b Positions) (out Positions) {
 
 // Intersect returns the intersection of a and b.  a and b must be sorted in
 // advance.  Returned slice will be sorted.
+// a or b may be returned by Intersect, but neither a nor b will be modified.
 func (a Positions) Intersect(b Positions) (out Positions) {
 	switch {
 	case a.IsAllPositions():

--- a/stenographer.go
+++ b/stenographer.go
@@ -73,7 +73,7 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
-	v(1, "Using config:\n%v", conf)
+	v(1, "Using config:\n%+v", conf)
 	env, err := env.New(*conf)
 	if err != nil {
 		log.Fatalf("unable to set up stenographer environment: %v", err)

--- a/stenotype/stenotype.cc
+++ b/stenotype/stenotype.cc
@@ -222,7 +222,7 @@ void DropPrivileges() {
   LOG(INFO) << "Dropping privileges";
   if (getgid() == 0 || flag_gid != "") {
     if (flag_gid == "") {
-      flag_gid = "nobody";
+      flag_gid = "nogroup";
     }
     LOG(INFO) << "Dropping priviledges from " << getgid() << " to GID "
               << flag_gid;

--- a/thread/thread.go
+++ b/thread/thread.go
@@ -184,7 +184,7 @@ func (t *Thread) cleanUpOnLowDiskSpace() {
 			v(1, "Thread %v disk space is sufficient: %v > %v", t.id, df, t.conf.DiskFreePercentage)
 			return
 		}
-		v(0, "Thread %v disk usage is high (packet path=%q): %d%% free, %d files\n", t.id, t.packetPath, df, len(t.files))
+		v(0, "Thread %v disk usage is high (packet path=%q): %d%% < %d%% free, or %d > %d files\n", t.id, t.packetPath, df, t.conf.DiskFreePercentage, len(t.files), t.conf.MaxDirectoryFiles)
 		if len(t.files) == 0 {
 			log.Printf("Thread %v could not free up space:  no files available", t.id)
 		} else if err := t.deleteOldestThreadFile(); err != nil {


### PR DESCRIPTION
We had 'nobody', which isn't available by default on some systems.  'nogroup'
always should.