### PR TITLE
Fix error checking when opening files.

### DIFF
--- a/stenotype/aio.cc
+++ b/stenotype/aio.cc
@@ -188,9 +188,9 @@ Error Output::Rotate(const std::string& dirname, int64_t micros,
   std::string name = HiddenFile(dirname, micros);
   int fd = open(name.c_str(), O_CREAT | O_WRONLY | O_DSYNC | O_DIRECT, 0600);
   LOG(INFO) << "Opening packet file " << name << ": " << fd;
-  RETURN_IF_ERROR(Errno(fd > 0), "open");
+  RETURN_IF_ERROR(Errno(fd), "open");
   if (initial_size > 0) {
-    LOG_IF_ERROR(Errno(0 <= fallocate(fd, 0, 0, initial_size)), "fallocate");
+    LOG_IF_ERROR(Errno(fallocate(fd, 0, 0, initial_size)), "fallocate");
   }
   current_ = new io::SingleFile(this, dirname, micros, fd);
   files_.insert(current_);

--- a/stenotype/util.h
+++ b/stenotype/util.h
@@ -299,9 +299,9 @@ class ProducerConsumerQueue {
   DISALLOW_COPY_AND_ASSIGN(ProducerConsumerQueue);
 };
 
-// Errno returns a util::Status based on the current value of errno and the
-// success flag.  If success is true, returns OK.  Otherwise, returns a
-// FAILED_PRECONDITION error based on errno.
+// Errno returns an Error based on the current value of errno and the
+// return value of a standard syscall.  If ret is >= 0, returns OK.
+// Otherwise, returns an error based on errno.
 inline Error Errno(int ret = -1) {
   if (ret >= 0 || errno == 0) {
     return SUCCESS;


### PR DESCRIPTION
We used to have Errno() take a bool, and return an error if it was
false.  Now, we have Errno() take an int, and return an error if that
int is < 0.  However, we still appear to have a few cases floating
around where it is passed a bool.  Since a bool is either 0 or 1, this
means we never return an error. :(

Fixed in two places, and updated comment.