### PR TITLE
Add support for remote listening

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,8 +21,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"net"
+	"os"
 
 	"github.com/google/stenographer/base"
 )
@@ -53,7 +53,7 @@ type Config struct {
 	Interface     string
 	Flags         []string
 	Port          int
-	Host		  string // Location to listen.
+	Host          string // Location to listen.
 	CertPath      string // Directory where client and server certs are stored.
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"net"
 
 	"github.com/google/stenographer/base"
 )
@@ -52,6 +53,7 @@ type Config struct {
 	Interface     string
 	Flags         []string
 	Port          int
+	Host		  string // Location to listen.
 	CertPath      string // Directory where client and server certs are stored.
 }
 
@@ -89,5 +91,10 @@ func (c Config) Validate() error {
 			return fmt.Errorf("invalid index directory %q in configuration: %v", thread.IndexDirectory, err)
 		}
 	}
+
+	if host := net.ParseIP(c.Host); host == nil {
+		return fmt.Errorf("invalid listening location %q in configuration", c.Host)
+	}
+
 	return nil
 }

--- a/configs/steno.conf
+++ b/configs/steno.conf
@@ -7,6 +7,7 @@
   , "StenotypePath": "/usr/bin/stenotype"
   , "Interface": "em1"
   , "Port": 1234
+  , "Host": "127.0.0.1"
   , "Flags": []
   , "CertPath": "/etc/stenographer/certs"
 }

--- a/env/env.go
+++ b/env/env.go
@@ -76,7 +76,7 @@ func (e *Env) Serve() error {
 		return fmt.Errorf("cannot verify client cert: %v", err)
 	}
 	server := &http.Server{
-		Addr:      fmt.Sprintf("localhost:%d", e.conf.Port),
+		Addr:      fmt.Sprintf("%s:%d", e.conf.Host e.conf.Port),
 		TLSConfig: tlsConfig,
 	}
 	http.HandleFunc("/query", func(w http.ResponseWriter, r *http.Request) {

--- a/env/env.go
+++ b/env/env.go
@@ -76,7 +76,7 @@ func (e *Env) Serve() error {
 		return fmt.Errorf("cannot verify client cert: %v", err)
 	}
 	server := &http.Server{
-		Addr:      fmt.Sprintf("%s:%d", e.conf.Host e.conf.Port),
+		Addr:      fmt.Sprintf("%s:%d", e.conf.Host, e.conf.Port),
 		TLSConfig: tlsConfig,
 	}
 	http.HandleFunc("/query", func(w http.ResponseWriter, r *http.Request) {

--- a/stenocurl
+++ b/stenocurl
@@ -53,13 +53,14 @@ EOF
   exit 1
 fi
 
+HOST="$(/bin/cat "$STENOGRAPHER_CONFIG" | $JQ -r '.Host')"
 PORT="$(/bin/cat "$STENOGRAPHER_CONFIG" | $JQ -r '.Port')"
 CERTPATH="$(/bin/cat "$STENOGRAPHER_CONFIG" | $JQ -r '.CertPath')"
 if [ -z "$PORT" -o -z "$CERTPATH" ]; then
   echo "Unable to get port ($PORT) or certpath ($CERTPATH) from config ($STENOGRAPHER_CONFIG)" >&2
   exit 1
 fi
-URL="https://localhost:$PORT$PATH"  # PATH already starts with /
+URL="https://$HOST:$PORT$PATH"  # PATH already starts with /
 
 if [ ! -r "$CERTPATH/client_key.pem" ]; then
   echo "You do not have permission to access Stenographer data" >&2


### PR DESCRIPTION
Currently Stenographer does not support listening on an external interface. With these changes you can configure it to listen externally. However, by default, only local listening is enabled (because listening externally has security implications).

This is some functionality that would be awesome for myself and my organization to have in the default Stenographer build. 

There is a known issue with this code that breaks stenoread when it is committed. This is because the certs are signed with the name 'localhost', where they no longer pointing. Instead, stenoread points to a new 'Host' parameter in the configuration file. If you choose to accept this, I'd rather find out how you would want the certificate generation to be changed than assume that myself. 

In our environment, we are just generating the certs again, but that's probably not the best way to do things.