### PR TITLE
Added install script for EL7 and systemd support

### DIFF
--- a/base/base.go
+++ b/base/base.go
@@ -26,9 +26,9 @@ import (
 	"syscall"
 	"time"
 
-	"code.google.com/p/gopacket"
-	"code.google.com/p/gopacket/layers"
-	"code.google.com/p/gopacket/pcapgo"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcapgo"
 	"golang.org/x/net/context"
 )
 

--- a/blockfile/blockfile.go
+++ b/blockfile/blockfile.go
@@ -25,7 +25,7 @@ import (
 	"time"
 	"unsafe"
 
-	"code.google.com/p/gopacket"
+	"github.com/google/gopacket"
 	"github.com/google/stenographer/base"
 	"github.com/google/stenographer/indexfile"
 	"github.com/google/stenographer/query"

--- a/configs/systemd.conf
+++ b/configs/systemd.conf
@@ -1,3 +1,5 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/indexfile/indexfile.go
+++ b/indexfile/indexfile.go
@@ -26,7 +26,7 @@ import (
 	"os"
 	"strings"
 
-	"code.google.com/p/leveldb-go/leveldb/table"
+	"github.com/golang/leveldb/table"
 	"github.com/google/stenographer/base"
 	"github.com/google/stenographer/stats"
 	"golang.org/x/net/context"

--- a/install_el7.sh
+++ b/install_el7.sh
@@ -1,6 +1,25 @@
 #!/usr/bin/env bash
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# stenographer - full packet to disk capture
+#
+# stenographer is a simple, fast method of writing live packets to disk,
+# then requesting those packets after-the-fact for post-hoc analysis.
+
 #===============================================================#
-# Install Stenographer on CentOS 7.1
+# Installs Stenographer on CentOS 7.1
 #===============================================================#
 
 export KILLCMD=/usr/bin/pkill


### PR DESCRIPTION
Depends on pull from @nbareil to fix the references to Google Code repos. Then, basically translated the install.sh script to function on CentOS 7, which depends on the EPEL repo. Lastly, I added a systemd service file that functions on CentOS 7.x. I haven't tested it on the new Ubuntu systemd support.