### PR TITLE
blockfile: Fix overwriting 'blockData' before packet is read.

### DIFF
--- a/blockfile/blockfile.go
+++ b/blockfile/blockfile.go
@@ -125,7 +125,7 @@ func (b *BlockFile) Close() (err error) {
 // allPacketsIter implements Iter.
 type allPacketsIter struct {
 	*BlockFile
-	blockData        [1 << 20]byte
+	blockData        []byte
 	block            *C.struct_tpacket_hdr_v1
 	pkt              *C.struct_tpacket3_hdr
 	blockPacketsRead int
@@ -142,6 +142,7 @@ func (a *allPacketsIter) Next() bool {
 	}
 	for a.block == nil || a.blockPacketsRead == int(a.block.num_pkts) {
 		packetBlocksRead.Increment()
+		a.blockData = make([]byte, 1 << 20)
 		_, err := a.f.ReadAt(a.blockData[:], a.blockOffset)
 		if err == io.EOF {
 			a.done = true


### PR DESCRIPTION
When `stenoread` is used to query all packets in blocks,
struct 'allPacketsIter' is used.  The entire block
is read into 'allPacketsIter.blockData' and packets
to be sent to `stenoread` all refer to this byte slice.
Then, after one block is read, the blockfile module will
immediately load the next block.  Since the 'blockData'
is statically allocated, the loading of next block will
overwrite the data of yet to be sent packets, causing
corruption when `stenoread` tries to parse the packets
using `tcpdump`.

To fix it, this commit forces `allPacketsIter` function
to always `make([]byte, 1 << 20)` a new byte slice for
the next block, so that previous block data is always
retained until all packets in the block are sent to
`stenoread`.

Reported-by: Reid Price \<reid@awakenetworks.com\>
Signed-off-by: Alex Wang \<alex@awakenetworks.com\>