### PR TITLE
Added new file, correct spec file

### DIFF
--- a/get-latest-steno
+++ b/get-latest-steno
@@ -2,24 +2,28 @@
 
 commit=`curl https://api.github.com/repos/google/stenographer/commits/master | awk 'NR==2{print $0}' | awk -F'"' '{print $4}'`
 short_commit=`echo ${commit:0:7}`
+TMP=`mktemp -d`
+pushd $TMP
 
 # pull lastest versions checked in to github
 curl -L -J -O https://github.com/google/stenographer/archive/$commit.tar.gz
 
-# move and untar in expected rpmbuild directories
-mv ~/stenographer-$commit.tar.gz ~/rpmbuild/SOURCES/
-tar -xzf ~/rpmbuild/SOURCES/stenographer-$commit.tar.gz -C ~/rpmbuild/SOURCES/
+# create working directory for rpmbuild to use
+mkdir -p $TMP/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+
+# untar to pull latest specfile for use
+tar -xzf stenographer-$commit.tar.gz 
 
 # copy current spec file into the expected folder
-cp ~/rpmbuild/SOURCES/stenographer-$commit/stenographer.spec ~/rpmbuild/SPECS/ 
+cp $TMP/stenographer-$commit/stenographer.spec $TMP/rpmbuild/SPECS/ 
 
 # run rpmbuild to create source rpm
-rpmbuild -bs ~/rpmbuild/SPECS/stenographer.spec
+rpmbuild --define "_topdir $TMP/rpmbuild" -bs $TMP/rpmbuild/SPECS/stenographer.spec
 
 # use mock to create rpm for centos 7
 sudo mock -r epel-7-x86_64 --init
 sudo mock -r epel-7-x86_64 --clean
-sudo mock -r epel-7-x86_64 rebuild ~/rpmbuild/SRPMS/stenographer-*$short_commit.el7.src.rpm
+sudo mock -r epel-7-x86_64 rebuild $TMP/rpmbuild/SRPMS/stenographer-*$short_commit.el7.src.rpm
 
 
 

--- a/get-latest-steno
+++ b/get-latest-steno
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+commit=`curl https://api.github.com/repos/google/stenographer/commits/master | awk 'NR==2{print $0}' | awk -F'"' '{print $4}'`
+short_commit=`echo ${commit:0:7}`
+
+# pull lastest versions checked in to github
+curl -L -J -O https://github.com/google/stenographer/archive/$commit.tar.gz
+
+# move and untar in expected rpmbuild directories
+mv ~/stenographer-$commit.tar.gz ~/rpmbuild/SOURCES/
+tar -xzf ~/rpmbuild/SOURCES/stenographer-$commit.tar.gz -C ~/rpmbuild/SOURCES/
+
+# copy current spec file into the expected folder
+#cp ~/rpmbuild/SOURCES/stenographer-$commit/stenographer.spec ~/rpmbuild/SPECS/ 
+
+# run rpmbuild to create source rpm
+rpmbuild -bs ~/rpmbuild/SPECS/stenographer.spec
+
+# use mock to create rpm for centos 7
+sudo mock -r epel-7-x86_64 --init
+sudo mock -r epel-7-x86_64 --clean
+sudo mock -r epel-7-x86_64 rebuild ~/rpmbuild/SRPMS/stenographer-*$short_commit.el7.src.rpm
+
+
+

--- a/get-latest-steno
+++ b/get-latest-steno
@@ -11,7 +11,7 @@ mv ~/stenographer-$commit.tar.gz ~/rpmbuild/SOURCES/
 tar -xzf ~/rpmbuild/SOURCES/stenographer-$commit.tar.gz -C ~/rpmbuild/SOURCES/
 
 # copy current spec file into the expected folder
-#cp ~/rpmbuild/SOURCES/stenographer-$commit/stenographer.spec ~/rpmbuild/SPECS/ 
+cp ~/rpmbuild/SOURCES/stenographer-$commit/stenographer.spec ~/rpmbuild/SPECS/ 
 
 # run rpmbuild to create source rpm
 rpmbuild -bs ~/rpmbuild/SPECS/stenographer.spec

--- a/rpmbuild-steno-centos
+++ b/rpmbuild-steno-centos
@@ -24,6 +24,9 @@ curl -L -J -O https://github.com/google/stenographer/archive/$commit.tar.gz
 # create working directory for rpmbuild to use
 mkdir -p $TMP/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
+# copy current source
+cp stenographer-$commit.tar.gz $TMP/rpmbuild/SOURCES
+
 # untar to pull latest specfile for use
 tar -xzf stenographer-$commit.tar.gz 
 

--- a/rpmbuild-steno-centos
+++ b/rpmbuild-steno-centos
@@ -1,4 +1,17 @@
 #!/bin/bash
+# Copyright 2016 Johnathon Hall
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 commit=`curl https://api.github.com/repos/google/stenographer/commits/master | awk 'NR==2{print $0}' | awk -F'"' '{print $4}'`
 short_commit=`echo ${commit:0:7}`

--- a/rpmbuild-steno-centos
+++ b/rpmbuild-steno-centos
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2016 Johnathon Hall
+# Copyright 2016 Google Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stenographer.spec
+++ b/stenographer.spec
@@ -1,4 +1,4 @@
-%global commit0 89a9b664ba8ef2953abbc8bcf5908211e762d5ec
+%global commit0 %(curl https://api.github.com/repos/google/stenographer/commits/master | awk 'NR==2{print $0}' | awk -F'"' '{print $4}')
 %global shortcommit0 %(c=%{commit0}; echo ${c:0:7})
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=995136#c12
@@ -84,7 +84,7 @@ install -p -m 644 configs/systemd.conf %{buildroot}%{_prefix}/lib/systemd/system
 %attr(0500, stenographer, root) %caps(cap_net_admin,cap_net_raw,cap_ipc_lock=ep) %{_bindir}/stenotype
 %{_bindir}/stenoread
 %{_bindir}/stenocurl
-%{_binder}/stenokeys.sh
+%{_bindir}/stenokeys.sh
 
 %{_sysconfdir}/stenographer
 %attr(0750, stenographer, stenographer) %{_sysconfdir}/stenographer/certs


### PR DESCRIPTION
Added centos 7 script that will check out latest version of stenographer from github and use rpmbuild and mock to create latest stenographer rpm using epel-7-x86_64 template. 

added dynamic git commit id detection to spec file so that you can use spec file will current master branch on github.