### PR TITLE
Sternographer needs at least Go 1.6

### DIFF
--- a/install_el7.sh
+++ b/install_el7.sh
@@ -59,7 +59,7 @@ install_packages () {
 }
 
 install_golang () {
-	local _url="https://storage.googleapis.com/golang/go1.4.2.linux-amd64.tar.gz"
+	local _url="https://storage.googleapis.com/golang/go1.6.3.linux-amd64.tar.gz"
 
 	if (! which go &>/dev/null ); then
 		Info "Installing golang ..."


### PR DESCRIPTION
Using 1.4 causes stenographer to misread client certificate and throw error. At the end whole stenographer was unusable.

Stenographer server:
```
Jul 21 12:09:49 localhost stenographer[15077]: 2016/07/21 12:09:49 http: TLS handshake error from 127.0.0.1:53398: tls: client's certificate's extended key usage doesn't permit it to be used for client authentication
```

cURL:
```
curl: (35) SSL peer was unable to negotiate an acceptable set of security parameters.
```

Stenocurl debug:
```
[root@localhost stenographer]# stenocurl /debug -v
* About to connect() to 127.0.0.1 port 1234 (#0)
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 1234 (#0)
* Initializing NSS with certpath: sql:/etc/pki/nssdb
*   CAfile: /etc/stenographer/certs/ca_cert.pem
  CApath: none
* NSS: client certificate from file
*       subject: CN=127.0.0.1_client,C=XX,O=Stenographer
*       start date: Jul 21 09:11:15 2016 GMT
*       expire date: Dec 06 09:11:15 2043 GMT
*       common name: 127.0.0.1_client
*       issuer: CN=*.steno,O=Stenographer,C=XX
* NSS error -12227 (SSL_ERROR_HANDSHAKE_FAILURE_ALERT)
* SSL peer was unable to negotiate an acceptable set of security parameters.
* Closing connection 0
```

Additional information about Go restrictions (fixed in Go 1.6): https://github.com/golang/go/issues/11087