### PR TITLE
query: Swap the time adjustment for time query lookup.

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -180,11 +180,11 @@ func (a timeQuery) LookupIn(ctx context.Context, index *indexfile.IndexFile) (bp
 	// Note, we add a minute when doing 'before' queries and subtract a minute
 	// when doing 'after' queries, to make sure we actually get the time
 	// specified.
-	if !a[0].IsZero() && t.Before(a[0].Add(time.Minute)) {
+	if !a[0].IsZero() && t.Before(a[0].Add(-time.Minute)) {
 		v(2, "time query skipping %q", index.Name())
 		return base.NoPositions, nil
 	}
-	if !a[1].IsZero() && t.After(a[1].Add(-time.Minute)) {
+	if !a[1].IsZero() && t.After(a[1].Add(time.Minute)) {
 		v(2, "time query skipping %q", index.Name())
 		return base.NoPositions, nil
 	}


### PR DESCRIPTION
As the comment below (in query/query.go) says,

   Note, we add a minute when doing 'before' queries and
   subtract a minute when doing 'after' queries, to make
   sure we actually get the time specified.

However, the current implementation does the opposite.
e.g. adds one minute when checking for skipping in the
'after' query:

   if !a[0].IsZero() && t.Before(a[0].Add(time.Minute))

This commit swaps the adjustment.

Signed-off-by: Alex Wang \<alex@awakenetworks.com\>