### PR TITLE
blockfile: Correct order of strings in debug log

### DIFF
--- a/blockfile/blockfile.go
+++ b/blockfile/blockfile.go
@@ -137,7 +137,7 @@ func (a *allPacketsIter) Next() bool {
 	}
 	for a.block == nil || a.blockPacketsRead == int(a.block.num_pkts) {
 		packetBlocksRead.Increment()
-		a.blockData = make([]byte, 1 << 20)
+		a.blockData = make([]byte, 1<<20)
 		_, err := a.f.ReadAt(a.blockData[:], a.blockOffset)
 		if err == io.EOF {
 			a.done = true
@@ -220,7 +220,7 @@ func (b *BlockFile) Lookup(ctx context.Context, q query.Query, out *base.PacketC
 	defer b.mu.RUnlock()
 
 	var ci gopacket.CaptureInfo
-	v(2, "Blockfile %q looking up query %q", q.String(), b.name)
+	v(2, "Blockfile %q looking up query %q", b.name, q.String())
 	start := time.Now()
 	positions, err := b.positionsLocked(ctx, q)
 	if err != nil {


### PR DESCRIPTION
The formatting arguments were reversed, this corrects messages like:
  Blockfile "host 1.2.3.4" looking up query "/tmp/stenographer0/PKT0/0"
to be:
  Blockfile "/tmp/stenographer0/PKT0/0" looking up query "host 1.2.3.4"