### PR TITLE
fix timezone expression on query language example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ primitives:
 
     # Stenographer-specific time additions:
     before 2012-11-03T11:05:00Z      # Packets before a specific time (UTC)
-    after 2012-11-03T11:05:00-0700   # Packets after a specific time (with TZ)
+    after 2012-11-03T11:05:00-07:00  # Packets after a specific time (with TZ)
     before 45m ago        # Packets before a relative time
     before 3h ago         # Packets after a relative time
 


### PR DESCRIPTION
I tried to run "stenoread 'after 2012-11-03T11:05:00-0700'" based on query language examples in README.md, but an error occurred on my Debian sid server. I guess the timezone expression "-0700" may be "-07:00" according to RFC3339, and it worked fine on my server.