### PR TITLE
Adds datestamp and changelog to spec file

### DIFF
--- a/stenographer.spec
+++ b/stenographer.spec
@@ -1,37 +1,48 @@
+# I'd rather use `jq -r '.sha' to parse this out, but can't get it into mock
 %global commit0 %(curl https://api.github.com/repos/google/stenographer/commits/master | awk 'NR==2{print $0}' | awk -F'"' '{print $4}')
 %global shortcommit0 %(c=%{commit0}; echo ${c:0:7})
+%global builddate %(date +%Y%m%d)
+
+# NOTE: If you are creating an SRPM, you should hard-code the commit and datestamp to 
+# ensure consistency as follow. NOTE: remove all the #'s. rpmlint doesn't like commented
+# macros
+#%#global commit0 844b5a4e538b4a560550b227c28ac911833713dd
+#%#global shortcommit0 %#(c=%#{commit0}; echo ${c:0:7})
+#%#global builddate 20170607
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=995136#c12
 %global _dwz_low_mem_die_limit 0
 
-
 Name:           stenographer
-Version:        0.0
-Release:        1.git%{shortcommit0}%{?dist}
+Version:        0
+Release:        1.%{builddate}git%{shortcommit0}%{?dist}
 Summary:        A high-speed packet capture solution that provides indexed access
 
-License:       	Apache License, 2.0 
+License:        Apache License, 2.0
 URL:            https://github.com/google/stenographer
 Source0:        https://github.com/google/%{name}/archive/%{commit0}.tar.gz#/%{name}-%{commit0}.tar.gz
-
 
 BuildRequires:  libaio-devel, leveldb-devel, snappy-devel, gcc-c++, make
 BuildRequires:  libpcap-devel, libseccomp-devel, git
 BuildRequires:  golang
 
+
 Requires:       libaio, leveldb, snappy, libpcap, libseccomp
-Requires: 	tcpdump, curl, rpmlib(FileCaps), jq
+Requires:       tcpdump, curl, rpmlib(FileCaps), jq, systemd
 Requires(pre):  shadow-utils
 
+%{?systemd_requires}
+BuildRequires:  systemd
+
 %description
-Stenographer is a full-packet-capture utility for buffering packets to disk for 
+Stenographer is a full-packet-capture utility for buffering packets to disk for
 intrusion detection and incident response purposes. It provides a high-
 performance implementation of NIC-to-disk packet writing, handles deleting those
-files as disk fills up, and provides methods for reading back specific sets of 
+files as disk fills up, and provides methods for reading back specific sets of
 packets quickly and easily.
 
 %prep
-%setup -q -n %{name}-%{commit0}
+%autosetup -n %{name}-%{commit0}
 
 %build
 # Build stenographer
@@ -51,7 +62,7 @@ go get ./...
 set -e
 
 # *** ERROR: No build ID note found in /.../BUILDROOT/etcd-2.0.0-1.rc1.fc22.x86_64/usr/bin/etcd
-go build -o %{name} -a -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -v -x "$@"; 
+go build -o %{name} -a -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -v -x "$@";
 
 # Build stenotype
 (cd stenotype; make %{?_smp_mflags} )
@@ -74,8 +85,8 @@ install -p -m 644 configs/steno.conf   %{buildroot}%{_sysconfdir}/%{name}/config
 install -d %{buildroot}%{_sysconfdir}/security/limits.d
 install -p -m 644 configs/limits.conf  %{buildroot}%{_sysconfdir}/security/limits.d/stenographer.conf
 
-install -d %{buildroot}%{_prefix}/lib/systemd/system
-install -p -m 644 configs/systemd.conf %{buildroot}%{_prefix}/lib/systemd/system/stenographer.service
+install -d %{buildroot}%{_unitdir}
+install -p -m 644 configs/systemd.conf %{buildroot}%{_unitdir}/stenographer.service
 
 %files
 %doc README.md DESIGN.md LICENSE
@@ -91,7 +102,7 @@ install -p -m 644 configs/systemd.conf %{buildroot}%{_prefix}/lib/systemd/system
 %config(noreplace) %{_sysconfdir}/stenographer/*
 
 %{_sysconfdir}/security/limits.d/stenographer.conf
-%{_prefix}/lib/systemd/system/stenographer.service
+%{_unitdir}/stenographer.service
 
 %pre
 getent group stenographer  || groupadd -r stenographer
@@ -100,15 +111,17 @@ getent passwd stenographer || useradd -r -g stenographer -d / -s /sbin/nologin \
 exit 0
 
 %post
-echo << EOF
-===============================================================================
+%systemd_post %{name}.service
 
-Configure data and index directories in '/etc/stenographer/config' and set them
-to be owned by the 'stenographer' user and group before starting the service
+%preun
+%systemd_preun %{name}.service
 
-===============================================================================
-EOF
-
-exit 0
+%postun
+%systemd_postun_with_restart %{name}.service
 
 %changelog
+
+* Wed Jun 7 2017 Derek Ditch <derek@rocknsm.io>
+- Added datestamp to allow for proper RPM progression
+- Minor cleanups in SPEC file
+- Added systemd as build-time dependency


### PR DESCRIPTION
- Adds datestamp to revision to get proper ordering per Fedora [Packaging Guidelines](https://fedoraproject.org/wiki/Packaging:Versioning)
- Adds note to set static values before creating an SRPM. This fixes and issue that if you
  package an SRPM today and then you compile it tomorrow, the commit and datestamp
  may be incorrect.
- Adds changelog
- Other cleanup noted in Changelog