### PR TITLE
Fix typo in mime header.

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -99,7 +99,7 @@ func (e *Env) handleQuery(w http.ResponseWriter, r *http.Request) {
 	ctx := httputil.Context(w, r, time.Minute*15)
 	defer ctx.Cancel()
 	packets := e.Lookup(ctx, q)
-	w.Header().Set("Content-Type", "appliation/octet-stream")
+	w.Header().Set("Content-Type", "application/octet-stream")
 	base.PacketsToFile(packets, w, limit)
 }
 


### PR DESCRIPTION
I was debugging HTTP headers and noticed this typo. Also, you should consider updating this to `application/vnd.tcpdump.pcap`, which is the [official mime type](http://www.netresec.com/?page=Blog&month=2011-04&post=PCAP-is-now-a-valid-MIME-type) for pcap.