### PR TITLE
Update steno.conf

### DIFF
--- a/configs/steno.conf
+++ b/configs/steno.conf
@@ -2,6 +2,8 @@
   "Threads": [
     { "PacketsDirectory": "/path/to/thread0/packets/directory"
     , "IndexDirectory": "/path/to/thread0/index/directory"
+    , "MaxDirectoryFiles": 30000
+    , "DiskFreePercentage": 10
     }
   ]
   , "StenotypePath": "/usr/bin/stenotype"


### PR DESCRIPTION
Adding in the default configurations into the stenographer's configuration file will enhance the self-documentation of the tool. This will make it easier to understand the behaviors of the tool without referencing the GitHub document.
The default values were obtained from:
https://github.com/google/stenographer/blob/master/INSTALL.md

To quote the the INSTALL.md document:

"MaxDirectoryFiles: The maximum number of packet/index files to create before cleaning old ones up. Defaults to 30K files..."
"Note that DiskFreePercentage is optional... it defaults to 10%."