### PR TITLE
Delete oldest files based on newest file size.

### DIFF
--- a/blockfile/blockfile.go
+++ b/blockfile/blockfile.go
@@ -67,6 +67,7 @@ func NewBlockFile(filename string, fc *filecache.Cache) (*BlockFile, error) {
 	f := fc.Open(filename)
 	s, err := f.Stat()
 	if err != nil {
+		f.Close()
 		return nil, fmt.Errorf("could not stat file %q: %v", filename, err)
 	}
 	return &BlockFile{

--- a/thread/thread.go
+++ b/thread/thread.go
@@ -205,7 +205,7 @@ func (t *Thread) cleanUpOnLowDiskSpace() {
 		}
 		v(0, "Thread %v disk usage is high (packet path=%q): %d%% free <= %d%% threshold", t.id, t.packetPath, df, t.conf.DiskFreePercentage)
 		if lastdf > df {
-			deleteFileCnt *= 2
+			delFileCnt *= 2
 			v(0, "Thread %v file deletion didn't surpass write speed. Increasing file deletion rate to %d", t.id, delFileCnt)
 		}
 		t.deleteOldestThreadFiles(delFileCnt)

--- a/thread/thread.go
+++ b/thread/thread.go
@@ -230,7 +230,7 @@ func (t *Thread) pruneOldestThreadFiles() {
 	firstSize := t.files[firstName].Size()
 	var delSize int64 = 0
 	delCnt := 0
-	for delSize < firstSize {
+	for delSize <= firstSize {
 		bf := t.files[files[delCnt]]
 		delSize += bf.Size()
 		delCnt++


### PR DESCRIPTION
This fixes an edge case where steno can't delete files fast enough after
long periods of low traffic followed by sustained high traffic.