### PR TITLE
Adds note about acceptable relative time values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ It is NOT designed for:
        alone can take >75% of a single core.
    *   Processing the data by reading it back from disk also doesn’t work:  see
        next bullet point.
+
 *   Reading back large amounts of packets (> 1% of packets written)
    *   The key concept here is that disk reads compete with disk writes… you can
        write at 90% of disk speed, but that only gives you 10% of your disk’s
@@ -62,6 +63,9 @@ primitives:
     after 2012-11-03T11:05:00-07:00  # Packets after a specific time (with TZ)
     before 45m ago        # Packets before a relative time
     before 3h ago         # Packets after a relative time
+
+**NOTE**: Relative times must be measured in integer values of hours or minutes
+as demonstrated above.
 
 Primitives can be combined with and/&& and with or/||, which have equal
 precendence and evaluate left-to-right.  Parens can also be used to group.


### PR DESCRIPTION
Took me a while to debug my app (https://github.com/rocknsm/docket) because I was parsing duration strings with Python libraries and rendering them to seconds as a common output. So `5m` would work, but when I converted it to `300.0s` it failed because "s" isn't supported, and the "." made the lexer assume it was an ip address. This note hopes to document that requirement.