### PR TITLE
Issue #167 Fix

### DIFF
--- a/thread/thread.go
+++ b/thread/thread.go
@@ -226,15 +226,23 @@ func tryToDeleteFile(filename string) {
 // checked by the caller beforehand).
 func (t *Thread) pruneOldestThreadFiles() {
 	files := t.getSortedFiles()
-	if len(files) == 0 {
+	v(2, "pruneOldestThreadFiles - files count %v, t.files count %v", len(files), len(t.files))
+	if len(files) == 0 || len(t.files) == 0 {
 		return
 	}
 	firstName := files[len(files)-1]
+	v(3, "pruneOldestThreadFiles - firstName %v", firstName)
+	if len(firstName) == 0 {
+		return
+	}
 	firstSize := t.files[firstName].Size()
-	var delSize int64 = 0
+	v(3, "pruneOldestThreadFiles - firstSize %v", firstSize)
+	var delSize int64
 	delCnt := 0
-	for delSize <= firstSize {
+	for delSize <= firstSize && delCnt < len(files) {
+		v(3, "pruneOldestThreadFiles - size loop - delCnt %v, len(files) %v", delCnt, len(files))
 		bf := t.files[files[delCnt]]
+		v(3, "pruneOldestThreadFiles - size loop - bf %v", bf)
 		delSize += bf.Size()
 		delCnt++
 	}


### PR DESCRIPTION
Relevant to Issue #167 

Root cause had to do with delCnt and len(files). If the file that was deleted wasn't enough to get below the required threshold, then the loop would continue, delCnt would be incremented, but if files was small - say a very small disk partition, then the index would cause a panic if the only file available to be deleted had been deleted and thus the len(files) was too small for the incremented delCnt.

(Second go at this - for whatever reason the merge from google/stenographer, which I did prior to the original PR, wasn't resolving the issue.)