### PR TITLE
query: improve performance of queries using Boolean operators

### DIFF
--- a/integration_test/test.sh
+++ b/integration_test/test.sh
@@ -19,7 +19,7 @@ PORT="${PORT-9123}"
 BASEDIR="${BASEDIR-/tmp}"
 SKIP_CLEANUP="${SKIP_CLEANUP}"
 SANITIZE="${SANITIZE}"
-PCAP_URL="ftp://ftp.ll.mit.edu/outgoing/darpa/data/2000/LLS_DDOS_1.0/data_and_labeling/tcpdump_inside/LLS_DDOS_1.0-inside.dump.gz"
+PCAP_URL="https://archive.ll.mit.edu/ideval/data/2000/LLS_DDOS_1.0/data_and_labeling/tcpdump_inside/LLS_DDOS_1.0-inside.dump.gz"
 
 set -e
 cd $(dirname $0)
@@ -28,7 +28,7 @@ source ../lib.sh
 function PullDownTestData {
   if [ ! -f $BASEDIR/steno_integration_test.pcap ]; then
     Info "Pulling down pcap data"
-    curl -L "$PCAP_URL" > $BASEDIR/steno_integration_test.pcap.gz
+    curl -k -L "$PCAP_URL" > $BASEDIR/steno_integration_test.pcap.gz
     gunzip $BASEDIR/steno_integration_test.pcap.gz
   fi
 }

--- a/query/query.go
+++ b/query/query.go
@@ -132,6 +132,9 @@ func (a unionQuery) LookupIn(ctx context.Context, index *indexfile.IndexFile) (b
 			return nil, err
 		}
 		positions = positions.Union(pos)
+		if positions.IsAllPositions() {
+			break
+		}
 	}
 	return positions, nil
 }
@@ -155,6 +158,9 @@ func (a intersectQuery) LookupIn(ctx context.Context, index *indexfile.IndexFile
 			return nil, err
 		}
 		positions = positions.Intersect(pos)
+		if positions.Len() == 0 {
+			break
+		}
 	}
 	return positions, nil
 }


### PR DESCRIPTION
At the moment, queries are always executed in their entirety against all index files (via `env.Lookup()` -> `thread.Lookup()` -> `blockfile.Lookup()`). See https://github.com/google/stenographer/blob/master/env/env.go#L274 and https://github.com/google/stenographer/blob/master/thread/thread.go#L346 etc..

That means that if a query cannot be satisfied in a block file, this information should be used as quickly as possible, to avoid doing useless queries before moving on to the next block file. For example, when doing time-based queries, it would be highly beneficial to quickly skip all block files that cannot satisfy the time constraint. Note that the time constraint is efficiently checked for the `timeQuery.LookupIn()` (https://github.com/google/stenographer/blob/master/query/query.go#L183 and https://github.com/google/stenographer/blob/master/query/query.go#L187) so that's nice. We quickly get a `NoPositions` or `AllPositions` result, which can then be used to mask result positions in the rest of the query, depending on what that looks like.

However, in complex queries that involve Boolean operations, this information is not used well, even if the time constraint is in the leftmost position of the query. That is, all subqueries connected by a boolean operator will be executed, regardless of satisfiability. 

For example, consider the following query (parentheses just for clarity):
```
(after 2020-01-27T12:27:28Z and before 2020-01-27T12:27:30Z) and (host 16.0.0.27) and (host 48.0.49.119)
```

For example, if the leftmost time query already yields `NoPositions`, the current code (https://github.com/google/stenographer/blob/master/query/query.go#L153) still evaluates _all_ other subqueries, even though there is no chance that the overall result will ever be anything else than `NoPositions`! Calculating the actual intersections is indeed efficient as the `NoPositions` and `AllPositions` corner cases are handled in `positions.Intersect()` but still, all sets of positions are uselessly looked up first... for each file.

A quick fix is to simply stop processing a Boolean query if it either cannot be satisfied (intersect) or already contains all positions (union). This might also be of interest for #164.

Here's a comparison of the stats for just one such lookup before (first set) and after applying the patch in this PR (second set):
```
$ sudo stenocurl /debug/stats
aged_files	0
current_files	34437
http_request_query_POST_bytes	1248
http_request_query_POST_completed	1
http_request_query_POST_nanos	244806627
index_base_lookup_nanos	7467135136
index_base_lookups_finished	137748
index_base_lookups_started	137748
index_set_lookup_nanos	13318881198
index_set_lookups_finished	103311
index_set_lookups_started	103311
indexfile_current_reads	0
indexfile_read_nanos	7218534663
indexfile_reads	68874
oldest_timestamp	1579887225653536000
packet_read_nanos	66586
packet_scan_nanos	0
packets_blocks_read	0
packets_read	11
packets_scanned	0
removed_hidden_files	8
removed_mismatched_files	0
```

```
$ sudo stenocurl /debug/stats
aged_files	0
current_files	34437
http_request_query_POST_bytes	1248
http_request_query_POST_completed	1
http_request_query_POST_nanos	142570293
index_base_lookup_nanos	80473277
index_base_lookups_finished	35702
index_base_lookups_started	35702
index_set_lookup_nanos	838987244
index_set_lookups_finished	103311
index_set_lookups_started	103311
indexfile_current_reads	0
indexfile_read_nanos	18491377
indexfile_reads	24
oldest_timestamp	1579887225653536000
packet_read_nanos	458760
packet_scan_nanos	0
packets_blocks_read	0
packets_read	11
packets_scanned	0
removed_hidden_files	8
removed_mismatched_files	3
```
In both cases, I simply restarted the stenographer process before each query, replacing the binary with a patched version. As you can see, the number of base lookups goes down significantly (~75%).

I hope I understood the overall situation correctly and I would be happy to have contributed to an improvement in lookup performance.