### PR TITLE
bug: slowly increasing time drift tampers with index look-ups

### DIFF
--- a/stenotype/Makefile
+++ b/stenotype/Makefile
@@ -14,9 +14,9 @@
 
 DEPS=Makefile *.h
 
-# remove this flag, if a monotonic clock reading is preferred
-# see util.h, GetCurrentTimeNanos()   
-DEFINES=-DUSE_CLOCK_REALTIME
+# if a monotonic clock reading is preferred, see util.h, GetCurrentTimeNanos(),
+# set the USE_MONOTONIC_TIME flag
+DEFINES=
 ifneq (,$(wildcard /usr/include/testimony.h))
 DEFINES += -DTESTIMONY
 DEPS += /usr/include/testimony.h

--- a/stenotype/Makefile
+++ b/stenotype/Makefile
@@ -25,7 +25,7 @@ endif
 ifneq (,$(wildcard /usr/bin/c++))
 CXX=/usr/bin/c++
 endif
-SHARED_CFLAGS=-std=c++0x -g -Wall -fno-strict-aliasing $(DEFINES)
+SHARED_CFLAGS=-std=c++0x -Wall -fno-strict-aliasing $(DEFINES)
 SHARED_LDFLAGS=-lleveldb -lrt -laio -lpthread -lsnappy -lseccomp
 ifneq (,$(wildcard /usr/include/testimony.h))
 SHARED_LDFLAGS += -ltestimony
@@ -36,7 +36,7 @@ OPT_CFLAGS=-O2 $(OPT_CFLAGS_SEC)
 OPT_LDFLAGS_SEC=-Wl,-z,now -Wl,-z,relro
 OPT_LDFLAGS=$(OPT_LDFLAGS_SEC)
 
-DBG_CFLAGS=-fno-omit-frame-pointer -O1 -fno-optimize-sibling-calls
+DBG_CFLAGS=-g -fno-omit-frame-pointer -O1 -fno-optimize-sibling-calls
 DBG_LDFLAGS=
 
 FILES=util packets index aio stenotype

--- a/stenotype/Makefile
+++ b/stenotype/Makefile
@@ -14,7 +14,9 @@
 
 DEPS=Makefile *.h
 
-DEFINES=
+# remove this flag, if a monotonic clock reading is preferred
+# see util.h, GetCurrentTimeNanos()   
+DEFINES=-DUSE_CLOCK_REALTIME
 ifneq (,$(wildcard /usr/include/testimony.h))
 DEFINES += -DTESTIMONY
 DEPS += /usr/include/testimony.h

--- a/stenotype/util.h
+++ b/stenotype/util.h
@@ -73,9 +73,15 @@ const int64_t kNumNanosPerSecond =
 
 inline int64_t GetCurrentTimeNanos() {
   struct timespec tv;
+#ifndef USE_CLOCK_REALTIME
   clock_gettime(clock_mono_id, &tv);
   int64_t secs = clock_realtime.tv_sec - clock_monotonic.tv_sec + tv.tv_sec;
   int64_t nsecs = clock_realtime.tv_nsec - clock_monotonic.tv_nsec + tv.tv_nsec;
+#else
+  clock_gettime(CLOCK_REALTIME, &tv);
+  int64_t secs = tv.tv_sec;
+  int64_t nsecs = tv.tv_nsec;
+#endif  
   return secs * 1000000000 + nsecs;
 }
 inline int64_t GetCurrentTimeMicros() { return GetCurrentTimeNanos() / 1000; }

--- a/stenotype/util.h
+++ b/stenotype/util.h
@@ -73,14 +73,14 @@ const int64_t kNumNanosPerSecond =
 
 inline int64_t GetCurrentTimeNanos() {
   struct timespec tv;
-#ifndef USE_CLOCK_REALTIME
-  clock_gettime(clock_mono_id, &tv);
-  int64_t secs = clock_realtime.tv_sec - clock_monotonic.tv_sec + tv.tv_sec;
-  int64_t nsecs = clock_realtime.tv_nsec - clock_monotonic.tv_nsec + tv.tv_nsec;
-#else
+#ifndef USE_MONOTONIC_TIME
   clock_gettime(CLOCK_REALTIME, &tv);
   int64_t secs = tv.tv_sec;
   int64_t nsecs = tv.tv_nsec;
+#else
+  clock_gettime(clock_mono_id, &tv);
+  int64_t secs = clock_realtime.tv_sec - clock_monotonic.tv_sec + tv.tv_sec;
+  int64_t nsecs = clock_realtime.tv_nsec - clock_monotonic.tv_nsec + tv.tv_nsec;
 #endif  
   return secs * 1000000000 + nsecs;
 }


### PR DESCRIPTION
This PR is a collaboration between @lassulus and me. 

When running Stenographer for a long stretch of time, Stenographer's time-based index look-ups get increasingly (though slowly) less accurate due to a clock skew affecting the timestamped index file names.

This error can be observed best, by tracking the difference between an index filename and its creation time over a long period of time (on our system we noticed ~ 5 seconds per day, but this will definitely vary between environments). Ultimately,  queries submitted via `stenoread` require an ever larger time-bracket for a successful response, though the actual packets returned will show the expected timestamp. 

The time drift originates in using monotonic time measurements, i.e., `CLOCK_MONOTONIC` or rather `CLOCK_MONOTONIC_RAW`.  We suspect, that `Stenotype`'s designers have deliberatly decided for this "nonstandard clock" mode to avoid index file collisions or index look-up inconsistencies due to a change of the system's clock time, e.g., by an inadvertent or careless user interaction. In a typical server-environment, time adjustments are supposed to occur in an orderly fashion only, e.g., via NTP.

The PR introduces the `USE_CLOCK_REALTIME` build flag to force a realtime clock read. We do not expect a performance hit as, e.g., *Professional Linux Kernel Architecture*, Mauerer, Wolfgang, Wrox, 2008, mentions only that

> read[ing] the fine-grained time [...] is simple for the monotonic clock (the value delivered by the current clock source can be directly used), but some straightforward arithmetic is required to convert the value into the real system time.

This flag has been set in `Stenotype`'s `Makefile` as a default; in case the original monotonic behavior is desired instead, this setting has to be actively overridden at build-time. 
