### PR TITLE
Add testimony socket config option to stenographer

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -49,23 +49,23 @@ type ThreadConfig struct {
 
 // RpcConfig is a json-decoded configuration for running the gRPC server.
 type RpcConfig struct {
-        CaCert                  string
-        ServerKey               string
-        ServerCert              string
-        ServerPort              int
-        ServerPcapPath          string
-        ServerPcapMaxSize       int64
-        ClientPcapChunkSize     int64
-        ClientPcapMaxSize       int64
+	CaCert              string
+	ServerKey           string
+	ServerCert          string
+	ServerPort          int
+	ServerPcapPath      string
+	ServerPcapMaxSize   int64
+	ClientPcapChunkSize int64
+	ClientPcapMaxSize   int64
 }
 
 // Config is a json-decoded configuration for running stenographer.
 type Config struct {
-    Rpc             *RpcConfig
+	Rpc             *RpcConfig
 	StenotypePath   string
 	Threads         []ThreadConfig
 	Interface       string
-    TestimonySocket string
+	TestimonySocket string
 	Flags           []string
 	Port            int
 	Host            string // Location to listen.
@@ -111,9 +111,9 @@ func (c Config) Validate() error {
 		}
 	}
 
-    if len(c.TestimonySocket) > 0 && len(c.Interface) > 0 {
-        return fmt.Errorf("Can't use both \"Interface\" and \"TestimonySocket\" options")
-    }
+	if len(c.TestimonySocket) > 0 && len(c.Interface) > 0 {
+		return fmt.Errorf("Can't use both \"Interface\" and \"TestimonySocket\" options")
+	}
 
 	if host := net.ParseIP(c.Host); host == nil {
 		return fmt.Errorf("invalid listening location %q in configuration", c.Host)

--- a/config/config.go
+++ b/config/config.go
@@ -61,15 +61,16 @@ type RpcConfig struct {
 
 // Config is a json-decoded configuration for running stenographer.
 type Config struct {
-        Rpc           *RpcConfig
-	StenotypePath string
-	Threads       []ThreadConfig
-	Interface     string
-	Flags         []string
-	Port          int
-	Host          string // Location to listen.
-	CertPath      string // Directory where client and server certs are stored.
-	MaxOpenFiles  int    // Max number of file descriptors opened at once
+    Rpc             *RpcConfig
+	StenotypePath   string
+	Threads         []ThreadConfig
+	Interface       string
+    TestimonySocket string
+	Flags           []string
+	Port            int
+	Host            string // Location to listen.
+	CertPath        string // Directory where client and server certs are stored.
+	MaxOpenFiles    int    // Max number of file descriptors opened at once
 }
 
 // ReadConfigFile reads in the given JSON encoded configuration file and returns
@@ -109,6 +110,10 @@ func (c Config) Validate() error {
 			return fmt.Errorf("No index directory specified for thread %d in configuration", n)
 		}
 	}
+
+    if len(c.TestimonySocket) > 0 && len(c.Interface) > 0 {
+        return fmt.Errorf("Can't use both \"Interface\" and \"TestimonySocket\" options")
+    }
 
 	if host := net.ParseIP(c.Host); host == nil {
 		return fmt.Errorf("invalid listening location %q in configuration", c.Host)

--- a/env/env.go
+++ b/env/env.go
@@ -134,13 +134,13 @@ func New(c config.Config) (_ *Env, returnedErr error) {
 
 // args is the set of command line arguments to pass to stentype.
 func (d *Env) args() []string {
-    res := append(d.conf.Flags,
+	res := append(d.conf.Flags,
 		fmt.Sprintf("--threads=%d", len(d.conf.Threads)),
 		fmt.Sprintf("--dir=%s", d.Path()))
 
 	if len(d.conf.Interface) > 0 {
 		res = append(res, fmt.Sprintf("--iface=%s", d.conf.Interface))
-    }
+	}
 	if len(d.conf.TestimonySocket) > 0 {
 		res = append(res, fmt.Sprintf("--testimony=%s", d.conf.TestimonySocket))
 	}

--- a/env/env.go
+++ b/env/env.go
@@ -134,10 +134,17 @@ func New(c config.Config) (_ *Env, returnedErr error) {
 
 // args is the set of command line arguments to pass to stentype.
 func (d *Env) args() []string {
-	return append(d.conf.Flags,
+    res := append(d.conf.Flags,
 		fmt.Sprintf("--threads=%d", len(d.conf.Threads)),
-		fmt.Sprintf("--iface=%s", d.conf.Interface),
 		fmt.Sprintf("--dir=%s", d.Path()))
+
+	if len(d.conf.Interface) > 0 {
+		res = append(res, fmt.Sprintf("--iface=%s", d.conf.Interface))
+    }
+	if len(d.conf.TestimonySocket) > 0 {
+		res = append(res, fmt.Sprintf("--testimony=%s", d.conf.TestimonySocket))
+	}
+	return res
 }
 
 // stenotype returns a exec.Cmd which runs the stenotype binary with all of


### PR DESCRIPTION
Stenotype has an option for using testimony socket (if compiled with testimony support), but
there was no way to use it with stenographer.