### PR TITLE
added seccomp rules for prlimit64 and openat calls

### DIFF
--- a/stenotype/stenotype.cc
+++ b/stenotype/stenotype.cc
@@ -293,6 +293,8 @@ void CommonPrivileges(scmp_filter_ctx ctx) {
   SECCOMP_RULE_ADD(ctx, SCMP_ACT_ALLOW, SCMP_SYS(futex), 0);
   SECCOMP_RULE_ADD(ctx, SCMP_ACT_ALLOW, SCMP_SYS(restart_syscall), 0);
   // File operations.
+  SECCOMP_RULE_ADD(ctx, SCMP_ACT_ALLOW, SCMP_SYS(prlimit64), 0);
+  SECCOMP_RULE_ADD(ctx, SCMP_ACT_ALLOW, SCMP_SYS(openat), 0);
   SECCOMP_RULE_ADD(ctx, SCMP_ACT_ALLOW, SCMP_SYS(fallocate), 0);
   SECCOMP_RULE_ADD(ctx, SCMP_ACT_ALLOW, SCMP_SYS(ftruncate), 0);
   SECCOMP_RULE_ADD(ctx, SCMP_ACT_ALLOW, SCMP_SYS(fstat), 0);


### PR DESCRIPTION
Hi,

I had issues to get stenographer working in Ubuntu 18.04 (cf. #205). After a while of digging, I found out that they were SECCOMP related - I faced no issues when running stenographer with the "--seccomp=none" flag. 
What fixed it for me in the end, was to add two new SECCOMP rules for prlimit64 and openat. This pull requests adds those two rules.